### PR TITLE
Support other encodings on read failure

### DIFF
--- a/cfinterface/files/blockfile.py
+++ b/cfinterface/files/blockfile.py
@@ -17,7 +17,7 @@ class BlockFile:
 
     VERSIONS: Dict[str, List[Type[Block]]] = {}
     BLOCKS: List[Type[Block]] = []
-    ENCODING = "utf-8"
+    ENCODING = ["utf-8", "latin-1", "ascii"]
     STORAGE = "TEXT"
     __VERSION = "latest"
 
@@ -44,7 +44,11 @@ class BlockFile:
         :type content: str | bytes
         """
         reader = BlockReading(cls.BLOCKS, cls.STORAGE)
-        return cls(reader.read(content, cls.ENCODING, *args, **kwargs))
+        for encoding in cls.ENCODING:
+            try:
+                return cls(reader.read(content, encoding, *args, **kwargs))
+            except UnicodeDecodeError:
+                pass
 
     def write(self, to: Union[str, IO], *args, **kwargs):
         """

--- a/cfinterface/files/blockfile.py
+++ b/cfinterface/files/blockfile.py
@@ -44,11 +44,15 @@ class BlockFile:
         :type content: str | bytes
         """
         reader = BlockReading(cls.BLOCKS, cls.STORAGE)
-        for encoding in cls.ENCODING:
-            try:
-                return cls(reader.read(content, encoding, *args, **kwargs))
-            except UnicodeDecodeError:
-                pass
+        if type(cls.ENCODING) == str:
+            return cls(reader.read(content, cls.ENCODING, *args, **kwargs))
+        else:
+            for encoding in cls.ENCODING:
+                try:
+                    return cls(reader.read(content, encoding, *args, **kwargs))
+                except UnicodeDecodeError:
+                    pass
+        raise EncodingWarning("Failed to decode content with all specified encodings.")
 
     def write(self, to: Union[str, IO], *args, **kwargs):
         """

--- a/cfinterface/files/registerfile.py
+++ b/cfinterface/files/registerfile.py
@@ -17,7 +17,7 @@ class RegisterFile:
 
     VERSIONS: Dict[str, List[Type[Register]]] = {}
     REGISTERS: List[Type[Register]] = []
-    ENCODING = "utf-8"
+    ENCODING = ["utf-8", "latin-1", "ascii"]
     STORAGE = "TEXT"
     __VERSION = "latest"
 
@@ -63,7 +63,11 @@ class RegisterFile:
         :type content: str | bytes
         """
         reader = RegisterReading(cls.REGISTERS, cls.STORAGE, *args, **kwargs)
-        return cls(reader.read(content, cls.ENCODING, *args, **kwargs))
+        for encoding in cls.ENCODING:
+            try:
+                return cls(reader.read(content, encoding, *args, **kwargs))
+            except UnicodeDecodeError:
+                pass
 
     def write(self, to: Union[str, IO], *args, **kwargs):
         """

--- a/cfinterface/files/registerfile.py
+++ b/cfinterface/files/registerfile.py
@@ -63,11 +63,15 @@ class RegisterFile:
         :type content: str | bytes
         """
         reader = RegisterReading(cls.REGISTERS, cls.STORAGE, *args, **kwargs)
-        for encoding in cls.ENCODING:
-            try:
-                return cls(reader.read(content, encoding, *args, **kwargs))
-            except UnicodeDecodeError:
-                pass
+        if type(cls.ENCODING) == str:
+            return cls(reader.read(content, cls.ENCODING, *args, **kwargs))
+        else:
+            for encoding in cls.ENCODING:
+                try:
+                    return cls(reader.read(content, encoding, *args, **kwargs))
+                except UnicodeDecodeError:
+                    pass
+        raise EncodingWarning("Failed to decode content with all specified encodings.")
 
     def write(self, to: Union[str, IO], *args, **kwargs):
         """

--- a/cfinterface/files/sectionfile.py
+++ b/cfinterface/files/sectionfile.py
@@ -17,7 +17,7 @@ class SectionFile:
 
     VERSIONS: Dict[str, List[Type[Section]]] = {}
     SECTIONS: List[Type[Section]] = []
-    ENCODING = "utf-8"
+    ENCODING = ["utf-8", "latin-1", "ascii"]
     STORAGE = "TEXT"
     __VERSION = "latest"
 
@@ -44,7 +44,11 @@ class SectionFile:
         :type content: str | bytes
         """
         reader = SectionReading(cls.SECTIONS, cls.STORAGE)
-        return cls(reader.read(content, cls.ENCODING, *args, **kwargs))
+        for encoding in cls.ENCODING:
+            try:
+                return cls(reader.read(content, encoding, *args, **kwargs))
+            except UnicodeDecodeError:
+                pass
 
     def write(self, to: Union[str, IO], *args, **kwargs):
         """

--- a/cfinterface/files/sectionfile.py
+++ b/cfinterface/files/sectionfile.py
@@ -44,11 +44,15 @@ class SectionFile:
         :type content: str | bytes
         """
         reader = SectionReading(cls.SECTIONS, cls.STORAGE)
-        for encoding in cls.ENCODING:
-            try:
-                return cls(reader.read(content, encoding, *args, **kwargs))
-            except UnicodeDecodeError:
-                pass
+        if type(cls.ENCODING) == str:
+            return cls(reader.read(content, cls.ENCODING, *args, **kwargs))
+        else:
+            for encoding in cls.ENCODING:
+                try:
+                    return cls(reader.read(content, encoding, *args, **kwargs))
+                except UnicodeDecodeError:
+                    pass
+        raise EncodingWarning("Failed to decode content with all specified encodings.")
 
     def write(self, to: Union[str, IO], *args, **kwargs):
         """


### PR DESCRIPTION
Sometimes files can contain characters in a enconding different from UTF-8. In such cases you can try reading with other encodings until no decode error is encountered instead of terminating the program. Latin-1 is a common encoding for the Portuguese language.