### PR TITLE
Fix thousands separator

### DIFF
--- a/cfinterface/components/floatfield.py
+++ b/cfinterface/components/floatfield.py
@@ -52,7 +52,7 @@ class FloatField(Field):
     # Override
     def _textual_read(self, line: str) -> float:
         return float(
-            line[self._starting_position : self._ending_position].replace(
+            line[self._starting_position : self._ending_position].replace(",","").replace(
                 self.__sep, "."
             )
         )


### PR DESCRIPTION
This is a suggested fix for an issue I encountered while parsing `dsvagua` file from `inewave`. Numeric values using commas as thousands separators (for example, "1,000") were being incorrectly interpreted as NaN. However, I'm not sure if this is the most appropriate place in the codebase to apply the fix.